### PR TITLE
Add advanced Go practice curriculum

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,53 @@
+# Groundation: Advanced Go Programming Drills
+
+Groundation is a self-paced curriculum designed to help experienced Go programmers
+re-familiarize themselves with modern Go features and edge cases. Each level is a
+small scenario with accompanying tests that you can run to measure your progress.
+
+## How the curriculum works
+
+- The repository is organized into themed levels inside [`levels/`](levels/).
+- Every level contains:
+  - A `challenge.md` file that describes the scenario, the learning goals, and
+    additional reading recommendations.
+  - A Go package with starter code in `*.go` files. Many implementations include
+    `TODO` markers; you are encouraged to replace the naive implementations with
+    idiomatic solutions.
+  - A `*_test.go` file that defines the acceptance tests for the level. Tests are
+    initially skipped with `t.Skip(...)` calls so that the suite passes out of the
+    box. When you are ready to attempt the challenge, remove the relevant `t.Skip`
+    lines and implement the required functionality until the tests pass.
+- Levels are independent; you can tackle them in any order.
+
+## Getting started
+
+1. Install Go 1.22 or newer.
+2. Inspect the level directory you want to play through and read its
+   `challenge.md` file.
+3. Remove the `t.Skip` calls from the tests you want to activate.
+4. Run the test suite for that level. For example, to attempt the generics level:
+
+   ```bash
+   go test ./levels/01-generics
+   ```
+
+5. Iterate on the implementation until all activated tests pass.
+
+## Suggested progression
+
+| Level | Theme | Highlights |
+| ----- | ----- | ---------- |
+| 01 | Generics & type inference | Type constraints, generic algorithm design, zero-value pitfalls |
+| 02 | Concurrency primitives | Context cancellation, worker pools, channel ownership |
+| 03 | Advanced standard library usage | `io`, `encoding/json`, `errors`, functional options |
+
+Feel free to extend the curriculum with your own levels as your practice needs evolve.
+
+## Tips for success
+
+- Treat each level as a kata. Start with the naive solution and refactor toward idiomatic Go.
+- Explore the Go 1.18+ release notes for more context on generics, fuzzing, and runtime improvements.
+- Use tools such as `go test -run` to focus on a specific case and `go test -race` to uncover data races in concurrency-oriented levels.
+- Experiment with benchmarks (`go test -bench .`) when performance is a concern.
+
+Happy hacking and welcome back to Go!

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,4 @@
+module github.com/example/groundation
+
+go 1.22
+

--- a/levels/01-generics/challenge.md
+++ b/levels/01-generics/challenge.md
@@ -1,0 +1,44 @@
+# Level 01 – Generics & Type Inference
+
+This level focuses on writing expressive, type-safe APIs with generics. You'll
+work with type constraints, zero values, and higher-order functions that mirror
+capabilities from other languages while staying idiomatic in Go.
+
+## Learning goals
+
+- Design reusable generic functions and data structures.
+- Understand how type inference interacts with composite literals and function
+  arguments.
+- Build constraints that compose comparability and ordered semantics without
+  relying on external packages.
+- Handle zero values safely when transforming or aggregating slices and maps.
+
+## Exercises
+
+1. Implement functional-style helpers such as `MapSlice`, `Reduce`, and
+   `Partition` while avoiding unnecessary allocations.
+2. Build a `Max` function that uses Go 1.21's `cmp.Ordered` constraint and
+   returns an error when no candidates are provided.
+3. Implement a `Memoize` helper that stores computation results in a
+   concurrency-safe cache without leaking goroutines.
+4. Explore how Go handles generic methods by finishing the `RingBuffer[T]`
+   implementation.
+
+Remove the `t.Skip` lines in `generics_test.go` to activate the tests. Each test
+suite represents a stage; progress through them sequentially or jump to the
+scenarios that feel most relevant.
+
+## Bonus challenges
+
+- Extend the memoization helper to support cache invalidation.
+- Write benchmarks comparing the performance of generic helpers versus type-
+  specific implementations.
+- Experiment with [`constraints.Float`](https://pkg.go.dev/golang.org/x/exp/constraints)
+  and compare it with Go's standard library `cmp.Ordered`.
+
+## Recommended reading
+
+- [Go blog: "When to Use Generics"](https://go.dev/blog/when-generics)
+- [Go 1.18 Release Notes](https://go.dev/doc/go1.18)
+- [`cmp` package documentation](https://pkg.go.dev/cmp)
+- [`sync.Map` documentation](https://pkg.go.dev/sync#Map)

--- a/levels/01-generics/generics.go
+++ b/levels/01-generics/generics.go
@@ -1,0 +1,156 @@
+package generics
+
+import (
+	"cmp"
+	"context"
+	"errors"
+	"sync"
+)
+
+// ErrNoCandidates is returned by Max when no candidates were provided.
+var ErrNoCandidates = errors.New("generics: no candidates provided")
+
+// MapSlice applies fn to each element of in and returns a new slice with the results.
+// The current implementation is intentionally naive; optimize memory usage and
+// safety as part of the exercise.
+func MapSlice[T any, R any](in []T, fn func(T) R) []R {
+	if fn == nil {
+		return nil
+	}
+	out := make([]R, len(in))
+	for i, v := range in {
+		out[i] = fn(v)
+	}
+	return out
+}
+
+// Reduce folds the slice from left to right using fn, starting at init.
+// Customize this to behave well with nil slices and zero values.
+func Reduce[T any, R any](in []T, init R, fn func(R, T) R) R {
+	acc := init
+	for _, v := range in {
+		acc = fn(acc, v)
+	}
+	return acc
+}
+
+// Partition splits the input slice into two slices based on the predicate result.
+func Partition[T any](in []T, pred func(T) bool) (matches, rest []T) {
+	for _, v := range in {
+		if pred(v) {
+			matches = append(matches, v)
+		} else {
+			rest = append(rest, v)
+		}
+	}
+	return matches, rest
+}
+
+// Max returns the largest value among the provided candidates. When candidates is
+// empty an error is returned so callers can differentiate the case from the zero value.
+func Max[T cmp.Ordered](candidates ...T) (T, error) {
+	var zero T
+	if len(candidates) == 0 {
+		return zero, ErrNoCandidates
+	}
+	max := candidates[0]
+	for _, v := range candidates[1:] {
+		if v > max {
+			max = v
+		}
+	}
+	return max, nil
+}
+
+// Memoizer caches the results of invoking fn and is safe for concurrent use.
+type Memoizer[K comparable, V any] struct {
+	mu    sync.RWMutex
+	fn    func(context.Context, K) (V, error)
+	cache map[K]V
+	errs  map[K]error
+}
+
+// NewMemoizer constructs a Memoizer that wraps fn.
+func NewMemoizer[K comparable, V any](fn func(context.Context, K) (V, error)) *Memoizer[K, V] {
+	return &Memoizer[K, V]{
+		fn:    fn,
+		cache: make(map[K]V),
+		errs:  make(map[K]error),
+	}
+}
+
+// Get retrieves the cached value for key or computes it if not present. The context
+// can be used by fn to respect cancellation or deadlines. Duplicate computations for
+// the same key should be avoided by your enhanced implementation.
+func (m *Memoizer[K, V]) Get(ctx context.Context, key K) (V, error) {
+	m.mu.RLock()
+	if v, ok := m.cache[key]; ok {
+		m.mu.RUnlock()
+		return v, nil
+	}
+	if err, ok := m.errs[key]; ok {
+		m.mu.RUnlock()
+		var zero V
+		return zero, err
+	}
+	m.mu.RUnlock()
+
+	v, err := m.fn(ctx, key)
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if err != nil {
+		m.errs[key] = err
+		var zero V
+		return zero, err
+	}
+	m.cache[key] = v
+	return v, nil
+}
+
+// RingBuffer is a fixed-size circular buffer suitable for generic data.
+type RingBuffer[T any] struct {
+	data []T
+	head int
+	size int
+}
+
+// NewRingBuffer allocates a buffer that can hold capacity elements.
+func NewRingBuffer[T any](capacity int) *RingBuffer[T] {
+	if capacity <= 0 {
+		panic("generics: capacity must be positive")
+	}
+	return &RingBuffer[T]{
+		data: make([]T, capacity),
+	}
+}
+
+// Push inserts v into the buffer and returns the element that was evicted, along
+// with a boolean indicating whether an eviction took place.
+func (r *RingBuffer[T]) Push(v T) (evicted T, evictedOK bool) {
+	if len(r.data) == 0 {
+		return evicted, false
+	}
+	if r.size == len(r.data) {
+		evicted = r.data[r.head]
+		evictedOK = true
+	}
+	r.data[r.head] = v
+	r.head = (r.head + 1) % len(r.data)
+	if r.size < len(r.data) {
+		r.size++
+	}
+	return evicted, evictedOK
+}
+
+// Snapshot returns the current contents of the buffer in FIFO order.
+func (r *RingBuffer[T]) Snapshot() []T {
+	if r.size == 0 {
+		return nil
+	}
+	out := make([]T, r.size)
+	for i := 0; i < r.size; i++ {
+		idx := (r.head - r.size + i + len(r.data)) % len(r.data)
+		out[i] = r.data[idx]
+	}
+	return out
+}

--- a/levels/01-generics/generics_test.go
+++ b/levels/01-generics/generics_test.go
@@ -1,0 +1,124 @@
+package generics
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestMapReducePartition(t *testing.T) {
+	t.Skip("TODO: remove this skip to attempt the Map/Reduce/Partition exercises")
+
+	squares := MapSlice([]int{1, 2, 3, 4}, func(v int) int { return v * v })
+	if len(squares) != 4 {
+		t.Fatalf("expected 4 squares, got %d", len(squares))
+	}
+	expected := []int{1, 4, 9, 16}
+	for i, v := range expected {
+		if squares[i] != v {
+			t.Fatalf("squares[%d] = %d, want %d", i, squares[i], v)
+		}
+	}
+
+	sum := Reduce(squares, 0, func(acc, next int) int { return acc + next })
+	if sum != 30 {
+		t.Fatalf("expected sum 30, got %d", sum)
+	}
+
+	evens, odds := Partition(squares, func(v int) bool { return v%2 == 0 })
+	if len(evens) != 2 || len(odds) != 2 {
+		t.Fatalf("expected 2 evens and 2 odds, got %d/%d", len(evens), len(odds))
+	}
+}
+
+func TestMax(t *testing.T) {
+	t.Skip("TODO: remove this skip to activate the Max challenge")
+
+	max, err := Max(1, 4, 2, 9, 3)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if max != 9 {
+		t.Fatalf("expected max 9, got %d", max)
+	}
+
+	_, err = Max[int]()
+	if !errors.Is(err, ErrNoCandidates) {
+		t.Fatalf("expected sentinel error, got %v", err)
+	}
+}
+
+func TestMemoizer(t *testing.T) {
+	t.Skip("TODO: remove this skip to explore the Memoizer")
+
+	var calls atomic.Int32
+	memo := NewMemoizer(func(ctx context.Context, key string) (string, error) {
+		calls.Add(1)
+		select {
+		case <-ctx.Done():
+			return "", ctx.Err()
+		case <-time.After(10 * time.Millisecond):
+			return key + "!", nil
+		}
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+
+	const workers = 8
+	var wg sync.WaitGroup
+	wg.Add(workers)
+	for i := 0; i < workers; i++ {
+		go func() {
+			defer wg.Done()
+			got, err := memo.Get(ctx, "echo")
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+			if got != "echo!" {
+				t.Errorf("expected echo!, got %q", got)
+			}
+		}()
+	}
+	wg.Wait()
+
+	if calls.Load() != 1 {
+		t.Fatalf("expected underlying function to run once, ran %d times", calls.Load())
+	}
+}
+
+func TestRingBuffer(t *testing.T) {
+	t.Skip("TODO: remove this skip to work on the RingBuffer")
+
+	buf := NewRingBuffer[int](3)
+	if snapshot := buf.Snapshot(); len(snapshot) != 0 {
+		t.Fatalf("expected empty snapshot, got %v", snapshot)
+	}
+
+	if _, evicted := buf.Push(1); evicted {
+		t.Fatalf("did not expect eviction on first push")
+	}
+	buf.Push(2)
+	buf.Push(3)
+	if snapshot := buf.Snapshot(); len(snapshot) != 3 {
+		t.Fatalf("expected 3 entries, got %v", snapshot)
+	}
+
+	evicted, ok := buf.Push(4)
+	if !ok || evicted != 1 {
+		t.Fatalf("expected to evict 1, got (%d, %v)", evicted, ok)
+	}
+	expected := []int{2, 3, 4}
+	if snapshot := buf.Snapshot(); len(snapshot) != len(expected) {
+		t.Fatalf("snapshot length mismatch: got %d want %d", len(snapshot), len(expected))
+	} else {
+		for i, v := range expected {
+			if snapshot[i] != v {
+				t.Fatalf("snapshot[%d] = %d, want %d", i, snapshot[i], v)
+			}
+		}
+	}
+}

--- a/levels/02-concurrency/challenge.md
+++ b/levels/02-concurrency/challenge.md
@@ -1,0 +1,39 @@
+# Level 02 – Concurrency Primitives & Patterns
+
+This level revisits the building blocks of concurrent Go applications. Practice
+coordinating goroutines, managing cancellation, and designing APIs that make
+ownership explicit.
+
+## Learning goals
+
+- Combine multiple producer channels into a single stream while respecting
+  cancellation semantics.
+- Design worker pools that propagate context errors and surface partial results.
+- Integrate ticker/rate-limiting logic to protect downstream services.
+- Encapsulate goroutine lifecycles to prevent leaks.
+
+## Exercises
+
+1. Rework `FanIn` to fairly multiplex values from N input channels until the
+   parent context is canceled.
+2. Finish `RateLimitedPool` so that it schedules work respecting the provided
+   QPS limit while capturing the first error encountered.
+3. Implement `WaitForAll` to join background goroutines and surface the most
+   relevant error.
+4. Polish `BoundedParallelMap` to process a stream without unbounded buffering.
+
+Refer to `concurrency_test.go` for specific acceptance criteria. Remove the
+`t.Skip` calls to activate the stages.
+
+## Bonus challenges
+
+- Swap the rate limiter for a token bucket and compare throughput.
+- Add metrics hooks (e.g., callbacks) to inspect worker lifecycle events.
+- Try running the tests with the race detector enabled: `go test -race ./...`.
+
+## Recommended reading
+
+- [Go blog: "Go Concurrency Patterns"](https://go.dev/blog/pipelines)
+- [`context` package documentation](https://pkg.go.dev/context)
+- [`golang.org/x/sync/errgroup`](https://pkg.go.dev/golang.org/x/sync/errgroup)
+- [Go blog: "First Class Functions in Go"](https://go.dev/blog/facode)

--- a/levels/02-concurrency/concurrency.go
+++ b/levels/02-concurrency/concurrency.go
@@ -1,0 +1,295 @@
+package concurrency
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"time"
+)
+
+// FanIn multiplexes the provided input channels into a single channel. The returned
+// channel is closed when the context is done or all producers have closed.
+func FanIn[T any](ctx context.Context, inputs ...<-chan T) <-chan T {
+	out := make(chan T)
+	var wg sync.WaitGroup
+	wg.Add(len(inputs))
+
+	forward := func(ch <-chan T) {
+		defer wg.Done()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case v, ok := <-ch:
+				if !ok {
+					return
+				}
+				select {
+				case out <- v:
+				case <-ctx.Done():
+					return
+				}
+			}
+		}
+	}
+
+	for _, ch := range inputs {
+		if ch == nil {
+			wg.Done()
+			continue
+		}
+		go forward(ch)
+	}
+
+	go func() {
+		wg.Wait()
+		close(out)
+	}()
+
+	return out
+}
+
+// RateLimitedPool processes tasks with a bounded level of concurrency and a
+// simple rate limit defined in requests-per-second. The first encountered error is
+// returned along with the partial results collected up to that point.
+func RateLimitedPool[T any, R any](ctx context.Context, workers int, qps int, tasks []T, fn func(context.Context, T) (R, error)) ([]R, error) {
+	if workers <= 0 {
+		return nil, errors.New("concurrency: workers must be positive")
+	}
+	if qps <= 0 {
+		return nil, errors.New("concurrency: qps must be positive")
+	}
+	if fn == nil {
+		return nil, errors.New("concurrency: fn must be provided")
+	}
+
+	results := make([]R, 0, len(tasks))
+	var mu sync.Mutex
+	var firstErr error
+
+	ticker := time.NewTicker(time.Second / time.Duration(qps))
+	defer ticker.Stop()
+
+	taskCh := make(chan T)
+	go func() {
+		defer close(taskCh)
+		for _, task := range tasks {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+			}
+			select {
+			case taskCh <- task:
+			case <-ctx.Done():
+				return
+			}
+		}
+	}()
+
+	var wg sync.WaitGroup
+	wg.Add(workers)
+	for i := 0; i < workers; i++ {
+		go func() {
+			defer wg.Done()
+			for task := range taskCh {
+				if ctx.Err() != nil {
+					return
+				}
+				res, err := fn(ctx, task)
+				mu.Lock()
+				if err != nil && firstErr == nil {
+					firstErr = err
+				}
+				if err == nil {
+					results = append(results, res)
+				}
+				mu.Unlock()
+			}
+		}()
+	}
+
+	wg.Wait()
+	if firstErr != nil {
+		return results, firstErr
+	}
+	if err := ctx.Err(); err != nil {
+		return results, err
+	}
+	return results, nil
+}
+
+// WaitForAll waits for the provided functions to complete. Each function is invoked
+// in its own goroutine. Any panics should be recovered and returned as errors.
+func WaitForAll(funcs ...func() error) error {
+	var wg sync.WaitGroup
+	var mu sync.Mutex
+	var firstErr error
+
+	for _, fn := range funcs {
+		if fn == nil {
+			continue
+		}
+		wg.Add(1)
+		go func(f func() error) {
+			defer wg.Done()
+			defer func() {
+				if r := recover(); r != nil {
+					mu.Lock()
+					if firstErr == nil {
+						firstErr = errors.New("panic recovered")
+					}
+					mu.Unlock()
+				}
+			}()
+			if err := f(); err != nil {
+				mu.Lock()
+				if firstErr == nil {
+					firstErr = err
+				}
+				mu.Unlock()
+			}
+		}(fn)
+	}
+
+	wg.Wait()
+	return firstErr
+}
+
+// BoundedParallelMap consumes values from the input channel, processes them with fn
+// using at most workers goroutines, and emits the transformed values while preserving
+// order. Closing the input channel signals completion. The returned channel is
+// closed after all work finishes or the context is canceled.
+func BoundedParallelMap[T any, R any](ctx context.Context, workers int, in <-chan T, fn func(context.Context, T) (R, error)) (<-chan R, <-chan error) {
+	out := make(chan R)
+	errCh := make(chan error, 1)
+
+	if workers <= 0 {
+		close(out)
+		errCh <- errors.New("concurrency: workers must be positive")
+		close(errCh)
+		return out, errCh
+	}
+	if fn == nil {
+		close(out)
+		errCh <- errors.New("concurrency: fn must be provided")
+		close(errCh)
+		return out, errCh
+	}
+
+	type task[T any] struct {
+		index int
+		value T
+	}
+	type result[R any] struct {
+		index int
+		value R
+		err   error
+	}
+
+	go func() {
+		defer close(out)
+		defer close(errCh)
+
+		tasks := make(chan task[T])
+		results := make(chan result[R])
+
+		var wg sync.WaitGroup
+		wg.Add(workers)
+		for i := 0; i < workers; i++ {
+			go func() {
+				defer wg.Done()
+				for task := range tasks {
+					if ctx.Err() != nil {
+						return
+					}
+					res, err := fn(ctx, task.value)
+					select {
+					case results <- result[R]{index: task.index, value: res, err: err}:
+					case <-ctx.Done():
+						return
+					}
+				}
+			}()
+		}
+
+		idx := 0
+		for v := range in {
+			select {
+			case <-ctx.Done():
+				close(tasks)
+				wg.Wait()
+				close(results)
+				return
+			case tasks <- task[T]{index: idx, value: v}:
+				idx++
+			}
+		}
+		close(tasks)
+		go func() {
+			wg.Wait()
+			close(results)
+		}()
+
+		next := 0
+		buffer := make(map[int]result[R])
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case res, ok := <-results:
+				if !ok {
+					for next < idx {
+						if stored, ok := buffer[next]; ok {
+							if stored.err != nil {
+								select {
+								case errCh <- stored.err:
+								default:
+								}
+							} else {
+								select {
+								case out <- stored.value:
+								case <-ctx.Done():
+									return
+								}
+							}
+						}
+						next++
+					}
+					return
+				}
+				if res.err != nil {
+					select {
+					case errCh <- res.err:
+					default:
+					}
+					buffer[res.index] = res
+					continue
+				}
+				buffer[res.index] = res
+				for {
+					stored, ok := buffer[next]
+					if !ok {
+						break
+					}
+					if stored.err != nil {
+						select {
+						case errCh <- stored.err:
+						default:
+						}
+					} else {
+						select {
+						case out <- stored.value:
+						case <-ctx.Done():
+							return
+						}
+					}
+					delete(buffer, next)
+					next++
+				}
+			}
+		}
+	}()
+
+	return out, errCh
+}

--- a/levels/02-concurrency/concurrency_test.go
+++ b/levels/02-concurrency/concurrency_test.go
@@ -1,0 +1,137 @@
+package concurrency
+
+import (
+	"context"
+	"errors"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestFanIn(t *testing.T) {
+	t.Skip("TODO: remove this skip to attempt the FanIn exercises")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+
+	producers := []<-chan int{
+		produce(ctx, []int{1, 3, 5}, 5*time.Millisecond),
+		produce(ctx, []int{2, 4, 6}, 7*time.Millisecond),
+	}
+
+	seen := map[int]bool{}
+	for v := range FanIn(ctx, producers...) {
+		seen[v] = true
+	}
+	for i := 1; i <= 6; i++ {
+		if !seen[i] {
+			t.Fatalf("missing value %d", i)
+		}
+	}
+}
+
+func produce(ctx context.Context, values []int, delay time.Duration) <-chan int {
+	ch := make(chan int)
+	go func() {
+		defer close(ch)
+		for _, v := range values {
+			select {
+			case <-ctx.Done():
+				return
+			case <-time.After(delay):
+			}
+			select {
+			case <-ctx.Done():
+				return
+			case ch <- v:
+			}
+		}
+	}()
+	return ch
+}
+
+func TestRateLimitedPool(t *testing.T) {
+	t.Skip("TODO: remove this skip to work on RateLimitedPool")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
+
+	var calls atomic.Int32
+	tasks := []int{1, 2, 3, 4}
+	start := time.Now()
+	results, err := RateLimitedPool(ctx, 2, 10, tasks, func(ctx context.Context, v int) (int, error) {
+		calls.Add(1)
+		return v * 2, nil
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if calls.Load() != int32(len(tasks)) {
+		t.Fatalf("expected %d calls, got %d", len(tasks), calls.Load())
+	}
+	if time.Since(start) < 300*time.Millisecond/10 {
+		t.Fatalf("rate limiter did not appear to engage")
+	}
+	if len(results) != len(tasks) {
+		t.Fatalf("expected %d results, got %d", len(tasks), len(results))
+	}
+}
+
+func TestWaitForAll(t *testing.T) {
+	t.Skip("TODO: remove this skip to activate WaitForAll")
+
+	err := WaitForAll(
+		func() error { return nil },
+		func() error { return errors.New("boom") },
+		func() error { panic("nope") },
+	)
+	if err == nil {
+		t.Fatalf("expected an error from WaitForAll")
+	}
+}
+
+func TestBoundedParallelMap(t *testing.T) {
+	t.Skip("TODO: remove this skip to take on BoundedParallelMap")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
+
+	in := make(chan int)
+	go func() {
+		defer close(in)
+		for i := 0; i < 6; i++ {
+			in <- i
+		}
+	}()
+
+	out, errs := BoundedParallelMap(ctx, 3, in, func(ctx context.Context, v int) (int, error) {
+		time.Sleep(5 * time.Millisecond)
+		if v == 4 {
+			return 0, errors.New("bad value")
+		}
+		return v * v, nil
+	})
+
+	var results []int
+	for v := range out {
+		results = append(results, v)
+	}
+	expected := []int{0, 1, 4, 9, 25}
+	if len(results) != len(expected) {
+		t.Fatalf("expected %d results, got %d", len(expected), len(results))
+	}
+	for i, v := range expected {
+		if results[i] != v {
+			t.Fatalf("results[%d] = %d, want %d", i, results[i], v)
+		}
+	}
+
+	select {
+	case err, ok := <-errs:
+		if !ok || err == nil {
+			t.Fatalf("expected to observe an error")
+		}
+	default:
+		t.Fatalf("expected an error to be reported")
+	}
+}

--- a/levels/03-stdlib/challenge.md
+++ b/levels/03-stdlib/challenge.md
@@ -1,0 +1,38 @@
+# Level 03 – Advanced Standard Library Practices
+
+This level highlights nuanced uses of the Go standard library. The exercises
+focus on robust I/O, JSON decoding edge cases, error wrapping, and iterating over
+filesystem state.
+
+## Learning goals
+
+- Implement defensive readers and writers that enforce size limits and deadlines.
+- Decode JSON streams with strict schema validation using `encoding/json`.
+- Combine `errors.Join` and `errors.Is` to build ergonomic error reporting.
+- Explore directory traversal with `fs.WalkDir` and contextual cancellation.
+
+## Exercises
+
+1. Harden `ReadAllWithLimit` so it fails fast on oversized payloads and respects
+   context cancellation.
+2. Implement `DecodeJSONStrict` to reject unknown fields while still supporting
+   optional values via pointers.
+3. Finish `Retry` to back off with jitter and wrap errors with attempt metadata.
+4. Complete `WalkDirFiltered` to combine file-system iteration with predicate
+   filtering and aggregated errors.
+
+See `stdlib_test.go` for testable requirements. Remove the `t.Skip` calls when
+you're ready for the challenge.
+
+## Bonus challenges
+
+- Extend `Retry` with circuit-breaker semantics.
+- Support streaming JSON decoding via `json.Decoder.Token`.
+- Implement file hashing using `crypto/sha256` inside the directory walker.
+
+## Recommended reading
+
+- [`io` package documentation](https://pkg.go.dev/io)
+- [`encoding/json` documentation](https://pkg.go.dev/encoding/json)
+- [Go 1.20 Release Notes](https://go.dev/doc/go1.20) for details on `errors.Join`.
+- [`io/fs` package documentation](https://pkg.go.dev/io/fs)

--- a/levels/03-stdlib/stdlib.go
+++ b/levels/03-stdlib/stdlib.go
@@ -1,0 +1,176 @@
+package stdlib
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"math/rand"
+	"path/filepath"
+	"sync"
+	"time"
+)
+
+// ErrLimitExceeded is returned when ReadAllWithLimit encounters more data than allowed.
+var ErrLimitExceeded = errors.New("stdlib: read limit exceeded")
+
+// ReadAllWithLimit reads from r until EOF or the limit is reached. If the context is
+// canceled before the read completes an error is returned. When the limit would be
+// exceeded, ErrLimitExceeded is returned.
+func ReadAllWithLimit(ctx context.Context, r io.Reader, limit int64) ([]byte, error) {
+	if limit <= 0 {
+		return nil, ErrLimitExceeded
+	}
+	buf := make([]byte, 0, int(min64(limit, 32*1024)))
+	tmp := make([]byte, 32*1024)
+	var total int64
+	for {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+		n, err := r.Read(tmp)
+		if n > 0 {
+			total += int64(n)
+			if total > limit {
+				return nil, ErrLimitExceeded
+			}
+			buf = append(buf, tmp[:n]...)
+		}
+		if errors.Is(err, io.EOF) {
+			return buf, nil
+		}
+		if err != nil {
+			return nil, err
+		}
+	}
+}
+
+// DecodeJSONStrict decodes data into a value of type T while disallowing unknown
+// fields. Pointer fields may remain nil when absent.
+func DecodeJSONStrict[T any](data []byte) (T, error) {
+	var zero T
+	dec := json.NewDecoder(bytes.NewReader(data))
+	dec.DisallowUnknownFields()
+	var out T
+	if err := dec.Decode(&out); err != nil {
+		return zero, err
+	}
+	if dec.More() {
+		return zero, errors.New("stdlib: trailing data")
+	}
+	return out, nil
+}
+
+// Retry invokes fn up to attempts times using exponential backoff with jitter. When
+// the context is canceled the retry loop stops immediately. The returned error wraps
+// all attempt errors via errors.Join.
+func Retry(ctx context.Context, attempts int, baseDelay time.Duration, fn func(context.Context) error) error {
+	if attempts <= 0 {
+		return errors.New("stdlib: attempts must be positive")
+	}
+	if baseDelay <= 0 {
+		baseDelay = 10 * time.Millisecond
+	}
+	if fn == nil {
+		return errors.New("stdlib: fn must be provided")
+	}
+
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	var errs []error
+
+	for i := 0; i < attempts; i++ {
+		if err := ctx.Err(); err != nil {
+			errs = append(errs, err)
+			break
+		}
+		attemptCtx, cancel := context.WithCancel(ctx)
+		err := fn(attemptCtx)
+		cancel()
+		if err == nil {
+			return nil
+		}
+		errs = append(errs, fmt.Errorf("stdlib: attempt %d failed: %w", i+1, err))
+		select {
+		case <-ctx.Done():
+			errs = append(errs, ctx.Err())
+			return errors.Join(errs...)
+		case <-time.After(backoffWithJitter(baseDelay, i, rng)):
+		}
+	}
+
+	if len(errs) == 0 {
+		return nil
+	}
+	return errors.Join(errs...)
+}
+
+func backoffWithJitter(base time.Duration, attempt int, rng *rand.Rand) time.Duration {
+	max := base << attempt
+	if max <= 0 {
+		max = base
+	}
+	if max > time.Second {
+		max = time.Second
+	}
+	jitter := time.Duration(rng.Int63n(int64(max/2 + 1)))
+	return max + jitter
+}
+
+// WalkDirFiltered walks fsys rooted at root collecting files for which filter returns true.
+// Errors encountered during traversal are aggregated via errors.Join.
+func WalkDirFiltered(ctx context.Context, fsys fs.FS, root string, filter func(fs.DirEntry) bool) ([]string, error) {
+	if fsys == nil {
+		return nil, errors.New("stdlib: fsys must be provided")
+	}
+
+	var mu sync.Mutex
+	var matches []string
+	var errs []error
+
+	walkErr := fs.WalkDir(fsys, root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			mu.Lock()
+			errs = append(errs, err)
+			mu.Unlock()
+			return nil
+		}
+		if d == nil {
+			return nil
+		}
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+		if filter != nil && !filter(d) {
+			return nil
+		}
+		if d.Type().IsRegular() {
+			mu.Lock()
+			matches = append(matches, filepath.ToSlash(path))
+			mu.Unlock()
+		}
+		return nil
+	})
+
+	if walkErr != nil && !errors.Is(walkErr, context.Canceled) {
+		errs = append(errs, walkErr)
+	}
+	if err := ctx.Err(); err != nil {
+		errs = append(errs, err)
+	}
+
+	var err error
+	if len(errs) > 0 {
+		err = errors.Join(errs...)
+	}
+	return matches, err
+}
+
+func min64(a int64, b int) int64 {
+	if a < int64(b) {
+		return a
+	}
+	return int64(b)
+}

--- a/levels/03-stdlib/stdlib_test.go
+++ b/levels/03-stdlib/stdlib_test.go
@@ -1,0 +1,123 @@
+package stdlib
+
+import (
+	"context"
+	"errors"
+	"io"
+	"io/fs"
+	"strings"
+	"testing"
+	"testing/fstest"
+	"time"
+)
+
+func TestReadAllWithLimit(t *testing.T) {
+	t.Skip("TODO: remove this skip to attempt ReadAllWithLimit")
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	data := strings.Repeat("a", 1024)
+
+	out, err := ReadAllWithLimit(ctx, strings.NewReader(data), 2048)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(out) != len(data) {
+		t.Fatalf("expected %d bytes, got %d", len(data), len(out))
+	}
+
+	if _, err := ReadAllWithLimit(ctx, strings.NewReader(data), 512); !errors.Is(err, ErrLimitExceeded) {
+		t.Fatalf("expected ErrLimitExceeded, got %v", err)
+	}
+
+	cancel()
+	if _, err := ReadAllWithLimit(ctx, slowReader{delay: 50 * time.Millisecond}, 2048); !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected context cancellation error, got %v", err)
+	}
+}
+
+type slowReader struct {
+	delay time.Duration
+}
+
+func (s slowReader) Read(p []byte) (int, error) {
+	time.Sleep(s.delay)
+	return copy(p, []byte("slow")), io.EOF
+}
+
+func TestDecodeJSONStrict(t *testing.T) {
+	t.Skip("TODO: remove this skip to work on DecodeJSONStrict")
+
+	type payload struct {
+		ID   int    `json:"id"`
+		Name string `json:"name"`
+	}
+	data := `{"id": 1, "name": "gopher"}`
+	got, err := DecodeJSONStrict[payload]([]byte(data))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.Name != "gopher" {
+		t.Fatalf("expected name gopher, got %q", got.Name)
+	}
+
+	bad := `{"id": 2, "nickname": "go"}`
+	if _, err := DecodeJSONStrict[payload]([]byte(bad)); err == nil {
+		t.Fatalf("expected unknown field error")
+	}
+}
+
+func TestRetry(t *testing.T) {
+	t.Skip("TODO: remove this skip to explore Retry")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
+
+	attempts := 0
+	err := Retry(ctx, 3, 10*time.Millisecond, func(context.Context) error {
+		attempts++
+		if attempts < 3 {
+			return errors.New("boom")
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("expected retry to eventually succeed, got %v", err)
+	}
+	if attempts != 3 {
+		t.Fatalf("expected 3 attempts, got %d", attempts)
+	}
+
+	attempts = 0
+	err = Retry(context.Background(), 2, 5*time.Millisecond, func(context.Context) error {
+		attempts++
+		return errors.New("still failing")
+	})
+	if err == nil {
+		t.Fatalf("expected aggregated error from retry")
+	}
+	if attempts != 2 {
+		t.Fatalf("expected 2 attempts, got %d", attempts)
+	}
+}
+
+func TestWalkDirFiltered(t *testing.T) {
+	t.Skip("TODO: remove this skip to take on WalkDirFiltered")
+
+	fsys := fstest.MapFS{
+		"root/a.txt":        {Data: []byte("a")},
+		"root/b/b.txt":      {Data: []byte("b")},
+		"root/b/ignore.tmp": {Data: []byte("tmp")},
+	}
+
+	ctx := context.Background()
+	paths, err := WalkDirFiltered(ctx, fsys, "root", func(d fs.DirEntry) bool {
+		return strings.HasSuffix(d.Name(), ".txt")
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(paths) != 2 {
+		t.Fatalf("expected 2 paths, got %d", len(paths))
+	}
+}


### PR DESCRIPTION
## Summary
- document the curriculum structure and usage workflow in the updated README
- add three gamified practice levels covering generics, concurrency, and advanced standard library patterns
- provide starter implementations and skip-gated test suites for each level to guide self-paced drills

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68e587c437548323b0f1040f8c0041ac